### PR TITLE
Update README on how to use with async options

### DIFF
--- a/README.md
+++ b/README.md
@@ -19,16 +19,13 @@ Use unpkg to access the UMD build:
 <script src="https://unpkg.com/react-select-fast-filter-options/dist/umd/react-select-fast-filter-options.js"></script>
 ```
 
+#### Examples
 Here's how to fast filter with [`react-select`](https://github.com/JedWatson/react-select) or [`react-virtualized-select`](https://github.com/bvaughn/react-virtualized-select):
 
 ```js
 // Import the Select component from either react-select or react-virtualized-select
 import Select from 'react-virtualized-select' // or from 'react-select'
 
-// Import the fast-filter library
-import createFilterOptions from 'react-select-fast-filter-options'
-
-// Create a search index optimized to quickly filter options.
 // The search index will need to be recreated if your options array changes.
 // This index is powered by js-search: https://github.com/bvaughn/js-search
 const filterOptions = createFilterOptions({ options })
@@ -43,6 +40,53 @@ function render ({ options }) {
     />
   )
 }
+```
+
+Here's how to fast filter with [`redux`](https://github.com/reactjs/redux), [`react-redux`](https://github.com/reactjs/react-redux), and [`reselect`](https://github.com/reactjs/reselect)
+
+##### `selectors/SomeDemoSelectors.js`
+```js
+// selectors file
+import { createSelector } from 'reselect';
+import createFilterOptions from 'react-select-fast-filter-options';
+
+const getSelectOptions = state => state.options;
+
+// Create a search index optimized to quickly filter options.
+// The search index will need to be recreated if your options array changes.
+// This index is powered by js-search: https://github.com/bvaughn/js-search
+// Reselect will only re-run this if options has changed
+const getIndexedOptions = createSelector(
+  getSelectOptions,
+  options => createFilterOptions({ options })
+)
+```
+
+##### `components/Search.js`
+```js
+// Import the Select component from either react-select or react-virtualized-select
+import Select from 'react-virtualized-select'; // or from 'react-select'
+import { connect } from 'react-redux';
+import { getIndexedOptions } from 'selectors/SomeDemoSelectors'
+
+// Render your Select, complete with the fast-filter index
+function render ({ options }) {
+  return (
+    <Select
+      filterOptions={filterOptions}
+      options={options}
+      {...otherSelectProps}
+    />
+  )
+}
+
+const mapStateToProps = (state) => ({
+  options: getIndexedOptions(state)
+})
+
+export default connect(mapStateToProps)(
+  render
+)
 ```
 
 ## Configuration Options

--- a/README.md
+++ b/README.md
@@ -2,9 +2,7 @@
 Fast `filterOptions` function for `react-select`;
 optimized to quickly filter huge options lists.
 
-## Getting started
-
-#### Installation
+## Installation
 
 The easiest way to install is using NPM:
 
@@ -19,7 +17,10 @@ Use unpkg to access the UMD build:
 <script src="https://unpkg.com/react-select-fast-filter-options/dist/umd/react-select-fast-filter-options.js"></script>
 ```
 
-#### Examples
+## Examples
+
+#### Basic example
+
 Here's how to fast filter with [`react-select`](https://github.com/JedWatson/react-select) or [`react-virtualized-select`](https://github.com/bvaughn/react-virtualized-select):
 
 ```js
@@ -44,30 +45,28 @@ function render ({ options }) {
 
 Here's how to fast filter with [`redux`](https://github.com/reactjs/redux), [`react-redux`](https://github.com/reactjs/react-redux), and [`reselect`](https://github.com/reactjs/reselect)
 
-##### `selectors/SomeDemoSelectors.js`
+#### Redux example
+
+##### selectors/SearchSelectors.js
 ```js
 // selectors file
 import { createSelector } from 'reselect';
 import createFilterOptions from 'react-select-fast-filter-options';
 
-const getSelectOptions = state => state.options;
-
 // Create a search index optimized to quickly filter options.
 // The search index will need to be recreated if your options array changes.
 // This index is powered by js-search: https://github.com/bvaughn/js-search
 // Reselect will only re-run this if options has changed
-const getIndexedOptions = createSelector(
-  getSelectOptions,
+export const getIndexedOptions = createSelector(
+  state => state.options,
   options => createFilterOptions({ options })
 )
 ```
 
-##### `components/Search.js`
+##### components/Search.js
 ```js
 // Import the Select component from either react-select or react-virtualized-select
 import Select from 'react-virtualized-select'; // or from 'react-select'
-import { connect } from 'react-redux';
-import { getIndexedOptions } from 'selectors/SomeDemoSelectors'
 
 // Render your Select, complete with the fast-filter index
 function render ({ options }) {
@@ -79,6 +78,9 @@ function render ({ options }) {
     />
   )
 }
+
+import { connect } from 'react-redux';
+import { getIndexedOptions } from 'selectors/SearchSelectors'
 
 const mapStateToProps = (state) => ({
   options: getIndexedOptions(state)


### PR DESCRIPTION
This new example is very specific to using both redux and reselect so not sure if it's worth to incorporating into the README, but this may be helpful for those specific users when incorporating this module into their app.

I considered adding an example without redux/reselect, but noticed that if I reindexed a large list in `componentWillReceiveProps`, there was a short UI lockup.

Thoughts?