### PR TITLE
Fix #10: babelHelper is not defined is ES version

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "presets": [
         "es2015",
         "react",
-        "stage-0"
+        "stage-2"
       ]
     },
     "development": {
@@ -37,14 +37,14 @@
       "presets": [
         "es2015",
         "react",
-        "stage-0"
+        "stage-2"
       ]
     },
     "es": {
       "presets": [
-        "es2015-rollup",
+        "es2015",
         "react",
-        "stage-0"
+        "stage-2"
       ]
     },
     "production": {
@@ -54,7 +54,7 @@
       "presets": [
         "es2015",
         "react",
-        "stage-0"
+        "stage-2"
       ]
     },
     "test": {
@@ -65,7 +65,7 @@
       "presets": [
         "es2015",
         "react",
-        "stage-0"
+        "stage-2"
       ]
     }
   },

--- a/package.json
+++ b/package.json
@@ -44,11 +44,11 @@
     ]
   },
   "dependencies": {
-    "js-search": "^1.3.1",
-    "react-select": "^1.0.0-beta14"
+    "js-search": "^1.3.1"
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-select": "^1.0.0-beta14"
   },
   "devDependencies": {
     "babel-cli": "6.8.0",
@@ -62,9 +62,8 @@
     "babel-plugin-typecheck": "^3.9.0",
     "babel-polyfill": "^6.5.0",
     "babel-preset-es2015": "^6.5.0",
-    "babel-preset-es2015-rollup": "^1.1.1",
     "babel-preset-react": "^6.5.0",
-    "babel-preset-stage-0": "^6.5.0",
+    "babel-preset-stage-2": "^6.5.0",
     "css-loader": "^0.25.0",
     "cross-env": "^3.1.3",
     "extract-text-webpack-plugin": "^1.0.1",


### PR DESCRIPTION
Use babel-preset-es2015 instead of babel-preset-es2015-rollup for building ES version (relates #10)

Move react-select to peer dependencies
Replace babel-preset-stage-0 with babel-preset-stage-2