### PR TITLE
Move react-select to devDependencies

### DIFF
--- a/package.json
+++ b/package.json
@@ -47,7 +47,8 @@
     "js-search": "^1.3.1" 
   },
   "peerDependencies": {
-    "react": "^0.14.0 || ^15.0.0"
+    "react": "^0.14.0 || ^15.0.0",
+    "react-select": "^1.0.0-beta14"
   },
   "devDependencies": {
     "babel-cli": "6.8.0",
@@ -75,7 +76,6 @@
     "react": "^15.3.1",
     "react-addons-shallow-compare": "^15.3.1",
     "react-dom": "^15.3.2",
-    "react-select": "^1.0.0-beta14",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
     "react-virtualized-select": "^1.3.0",

--- a/package.json
+++ b/package.json
@@ -44,8 +44,7 @@
     ]
   },
   "dependencies": {
-    "js-search": "^1.3.1",
-    "react-select": "^1.0.0-beta14"
+    "js-search": "^1.3.1" 
   },
   "peerDependencies": {
     "react": "^0.14.0 || ^15.0.0"
@@ -76,6 +75,7 @@
     "react": "^15.3.1",
     "react-addons-shallow-compare": "^15.3.1",
     "react-dom": "^15.3.2",
+    "react-select": "^1.0.0-beta14",
     "react-transform-catch-errors": "^1.0.2",
     "react-transform-hmr": "^1.0.4",
     "react-virtualized-select": "^1.3.0",


### PR DESCRIPTION
Hi!

I recently ran into a situation where I needed to fork react-select (to use an older version, but remove the React.PropTypes and React.createClass warnings).

With react-select listed in 'dependencies' for this package, I found that I was still getting warnings triggered due to both the fork and unforked versions of react-select being installed.

Solution for my use case was to move react-select to devDependencies instead, so submitting this PR for your consideration.